### PR TITLE
Change 'res.write' to 'res.send' to end a response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,6 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 app.get('/', (req, res) => {
-  res.write('<div style="padding: 20px"><h1>Neutrino</h1><p>Welcome to Express</p></div>');
+  res.send('<div style="padding: 20px"><h1>Neutrino</h1><p>Welcome to Express</p></div>');
 })
 .listen(port, () => console.log(`Running on :${port}`));


### PR DESCRIPTION
`res.write` without calling `res.end` does not return the response immediately.
`res.send` seems to be proper to this example.